### PR TITLE
fix inconsistent tabbing in handlers.py

### DIFF
--- a/tg_bot/modules/helper_funcs/handlers.py
+++ b/tg_bot/modules/helper_funcs/handlers.py
@@ -59,6 +59,6 @@ class GbanLockHandler(tg.CommandHandler):
                         res = any(func(message) for func in self.filters)
                     else:
                         res = self.filters(message)
-                     return res
-         return False
+                    return res
+        return False
 


### PR DESCRIPTION
This causes Python 3.7.3 to flip its lid.